### PR TITLE
Important changes on InputPassword for extra security 

### DIFF
--- a/src/components/manager/passwordList/InputPassword.js
+++ b/src/components/manager/passwordList/InputPassword.js
@@ -30,10 +30,9 @@ const InputPassword = ({ setPasswordChanges }) => {
         setShow(true);
         return alert("Fields can't be empty");
       } else {
-        // const { data } = await axiosPrivate.post("/passwords", passwordInfo);
-        await axiosPrivate.post("/passwords", passwordInfo);
+        const { data } = await axiosPrivate.post("/passwords", passwordInfo);
 
-        setPasswordChanges(true);
+        data === "ADDED to the password vault" && setPasswordChanges(true);
         setPasswordInfo({
           website: "",
           email: "",


### PR DESCRIPTION
Important changes on `InputPassword` for extra security & modified server to send Success JSON Message. In future if my server returns DATA on `POST /passwords` _endpoint for adding a password_, a note: I can modify it based on status code, upon 200 to fire `setPasswordChanges(true)` function. :)