### PR TITLE
Fixing the safari issue of not allowing 3rd party cookies -> make Aut…

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,4 +1,4 @@
 [[redirects]]
 from = '/*'
-to = '/index.html'
+to = 'https://password-manager.fly.dev'
 status = 200

--- a/src/Utils/api/axios.js
+++ b/src/Utils/api/axios.js
@@ -1,5 +1,7 @@
 import axios from "axios";
-const BASE_URL = "https://password-manager.fly.dev";
+// const BASE_URL = "http://localhost:3003";
+// const BASE_URL = "https://password-manager.fly.dev";
+const BASE_URL = "https://alek-password-manager.netlify.app";
 
 export default axios.create({ baseURL: BASE_URL });
 

--- a/src/components/manager/passwordList/InputPassword.js
+++ b/src/components/manager/passwordList/InputPassword.js
@@ -5,9 +5,7 @@ import { searchPassword } from "../../../redux/actions/searchBarActions";
 
 import { Button, Modal } from "react-bootstrap";
 import useAxiosPrivate from "../../../Hooks/useAxiosPrivate";
-import verifyActions, {
-  userAuthEnded,
-} from "../../../redux/actions/verifyActions";
+import { userAuthEnded } from "../../../redux/actions/verifyActions";
 
 const InputPassword = ({ setPasswordChanges }) => {
   const [passwordInfo, setPasswordInfo] = useState({


### PR DESCRIPTION
Fixing the safari issue (and phone mobile browsers alike) of not allowing (blocking) 3rd party cookies ~> make the Auth cookies as 1st party cookies using netlify's `**proxy** to another service`