### PR TITLE
Fixing the Auth cookies being set as 3rd party cookies issue

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,4 +1,4 @@
 [[redirects]]
-from = '/*'
+from = '/api'
 to = 'https://password-manager.fly.dev'
 status = 200

--- a/src/Utils/api/axios.js
+++ b/src/Utils/api/axios.js
@@ -1,7 +1,8 @@
 import axios from "axios";
 // const BASE_URL = "http://localhost:3003";
 // const BASE_URL = "https://password-manager.fly.dev";
-const BASE_URL = "https://alek-password-manager.netlify.app";
+// const BASE_URL = "https://alek-password-manager.netlify.app";
+const BASE_URL = "https://alek-password-manager.netlify.app/api";
 
 export default axios.create({ baseURL: BASE_URL });
 


### PR DESCRIPTION
Fixing the safari issue (and phone mobile browsers alike) of not allowing (blocking) third party cookies ~> Solution is to make the Auth cookies as first party cookies using netlify's **proxy** to another service