### PR TITLE
Fixing the Auth cookies being set as 3rd party cookies issue

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,4 +1,4 @@
 [[redirects]]
-from = '/api'
+from = '/api/'
 to = 'https://password-manager.fly.dev'
 status = 200


### PR DESCRIPTION
Fixing the safari issue (and phone mobile browsers alike) of not allowing (blocking) third party cookies ~> Solution is to make the Auth cookies as first party cookies using netlify's **proxy** to another service